### PR TITLE
Fix OAuth token resolution

### DIFF
--- a/dist/hdf5-indexed-reader.esm.js
+++ b/dist/hdf5-indexed-reader.esm.js
@@ -19,7 +19,7 @@ class RemoteFile {
 
         let url = this.url.slice();    // slice => copy
         if (this.config.oauthToken) {
-            const token = resolveToken(this.config.oauthToken);
+            const token = await resolveToken(this.config.oauthToken);
             headers['Authorization'] = `Bearer ${token}`;
         }
 

--- a/dist/hdf5-indexed-reader.node.cjs
+++ b/dist/hdf5-indexed-reader.node.cjs
@@ -54,7 +54,7 @@ class RemoteFile {
 
         let url = this.url.slice();    // slice => copy
         if (this.config.oauthToken) {
-            const token = resolveToken(this.config.oauthToken);
+            const token = await resolveToken(this.config.oauthToken);
             headers['Authorization'] = `Bearer ${token}`;
         }
 

--- a/dist/hdf5-indexed-reader.node.mjs
+++ b/dist/hdf5-indexed-reader.node.mjs
@@ -52,7 +52,7 @@ class RemoteFile {
 
         let url = this.url.slice();    // slice => copy
         if (this.config.oauthToken) {
-            const token = resolveToken(this.config.oauthToken);
+            const token = await resolveToken(this.config.oauthToken);
             headers['Authorization'] = `Bearer ${token}`;
         }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "mocha": "^10.2.0",
     "node": "^19.4.0",
     "node-fetch": "^2.6.0",
-    "rollup": "^3.10.0"
+    "rollup": "^3.10.0",
+    "sinon": "^18.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/io/remoteFile.js
+++ b/src/io/remoteFile.js
@@ -20,7 +20,7 @@ class RemoteFile {
 
         let url = this.url.slice()    // slice => copy
         if (this.config.oauthToken) {
-            const token = resolveToken(this.config.oauthToken)
+            const token = await resolveToken(this.config.oauthToken)
             headers['Authorization'] = `Bearer ${token}`
         }
 


### PR DESCRIPTION
Thanks for making this library available!  [Single Cell Portal](https://singlecell.broadinstitute.org/single_cell) finds it useful.  

This change enables fetching remote HDF5 files that require an OAuth token.  Previously, the `fetch` in `RemoteFile` passed an unresolved promise for the `Authorization` HTTP request header's value.  Now, the token value is properly resolved to a string.